### PR TITLE
Time module Bug Fix for Windows

### DIFF
--- a/SeleniumCookie/wrapper.py
+++ b/SeleniumCookie/wrapper.py
@@ -171,7 +171,7 @@ class Chrome:
         for item in cur.fetchall():
             host, path, secure, expires, name = item[:5]
             if item[3] != 0:
-                offset = min(int(item[3]), 265000000000000000)
+                offset = min(int(item[3]), 32536799999000000)
                 delta = datetime.timedelta(microseconds=offset)
                 expires = epoch_start + delta
                 expires = expires.timestamp()


### PR DESCRIPTION
Found the maximum supported timestamp in the datetime package to be 32536799999
Using it for cookie expiry.
Refer Issue: https://github.com/GDGVIT/Selenium-Cookie-Injector/issues/8#issue-551924190

@Geek-ubaid @L04DB4L4NC3R 