### PR TITLE
Changed package name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,8 @@ import setuptools
 from distutils.core import setup
 
 setup(
-    name='SeleniumCookie',
-    packages=['SeleniumCookie'],
+    name='SeleniumCookies',
+    packages=['SeleniumCookies'],
     version='0.2',
     license='MIT',
     description='COOKIE INJECTION FOR SELENIUM',


### PR DESCRIPTION
### What was breaking
`SeleniumCookie` pip package already existed, leading to failing package publish to the DSC-VIT `pypi` account.

### Change proposed
Package name changed to `SeleniumCookies`.